### PR TITLE
feat: add skipReferences option and id property

### DIFF
--- a/src/generator/model.ts
+++ b/src/generator/model.ts
@@ -1,5 +1,6 @@
-import { DMMF } from '@prisma/generator-helper'
+import { Dictionary, DMMF } from '@prisma/generator-helper'
 import { JSONSchema7Definition } from 'json-schema'
+import { isEnumType, isScalarType } from './helpers'
 import { getJSONSchemaProperty } from './properties'
 import { DefinitionMap, ModelMetaData } from './types'
 
@@ -9,11 +10,18 @@ function getRelationScalarFields(model: DMMF.Model): string[] {
     )
 }
 
-export function getJSONSchemaModel(modelMetaData: ModelMetaData) {
+export function getJSONSchemaModel(
+    modelMetaData: ModelMetaData,
+    options?: Dictionary<string>,
+) {
     return (model: DMMF.Model): DefinitionMap => {
-        const definitionPropsMap = model.fields.map(
-            getJSONSchemaProperty(modelMetaData),
-        )
+        const definitionPropsMap = model.fields
+            .filter((field) => {
+                return options?.skipReferences == 'true'
+                    ? isScalarType(field) || isEnumType(field)
+                    : true
+            })
+            .map(getJSONSchemaProperty(modelMetaData))
 
         const propertiesMap = definitionPropsMap.map(
             ([name, definition]) => [name, definition] as DefinitionMap,

--- a/src/generator/transformDMMF.ts
+++ b/src/generator/transformDMMF.ts
@@ -1,4 +1,4 @@
-import type { DMMF } from '@prisma/generator-helper'
+import type { Dictionary, DMMF } from '@prisma/generator-helper'
 import type { JSONSchema7, JSONSchema7Definition } from 'json-schema'
 import { DEFINITIONS_ROOT } from './constants'
 import { toCamelCase } from './helpers'
@@ -17,17 +17,23 @@ function getPropertyDefinition(
     ]
 }
 
-export function transformDMMF(dmmf: DMMF.Document): JSONSchema7 {
+export function transformDMMF(
+    dmmf: DMMF.Document,
+    options?: Dictionary<string>,
+): JSONSchema7 {
     const { models, enums } = dmmf.datamodel
     const initialJSON = getInitialJSON()
 
-    const modelDefinitionsMap = models.map(getJSONSchemaModel({ enums }))
+    const modelDefinitionsMap = models.map(
+        getJSONSchemaModel({ enums }, options),
+    )
     const modelPropertyDefinitionsMap = models.map(getPropertyDefinition)
     const definitions = Object.fromEntries(modelDefinitionsMap)
     const properties = Object.fromEntries(modelPropertyDefinitionsMap)
 
     return {
         ...initialJSON,
+        $id: typeof options?.id === 'string' ? options?.id : undefined,
         definitions,
         properties,
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,14 +11,17 @@ generatorHandler({
         }
     },
     async onGenerate(options) {
-        const jsonSchema = transformDMMF(options.dmmf)
+        const jsonSchema = transformDMMF(options.dmmf, options.generator.config)
         if (options.generator.output) {
             try {
                 await fs.promises.mkdir(options.generator.output, {
                     recursive: true,
                 })
                 await fs.promises.writeFile(
-                    path.join(options.generator.output, 'json-schema.json'),
+                    path.join(
+                        options.generator.output,
+                        options.generator.config.filename ?? 'json-schema.json',
+                    ),
                     JSON.stringify(jsonSchema, null, 2),
                 )
             } catch (e) {


### PR DESCRIPTION
As we need our prisma models like the typescript types the prisma-client generator is producing (without references between the models) I added a switch to the generator config to enable that functionality with the skipReferences flag.
As we also need an id to reference the schema I also added that + the functionality to decide on the filename by our own.